### PR TITLE
instruct users to always construct HttpTestPlayback with testDataDirectory

### DIFF
--- a/packages/botbuilder-http-test-recorder/README.md
+++ b/packages/botbuilder-http-test-recorder/README.md
@@ -56,7 +56,8 @@ const { HttpTestPlayback } = require('botbuilder-http-test-recorder');
 
 describe('My bot', () => {
   it('should ask a question', () => {
-    const playback = new HttpTestPlayback();
+    // folder name of your stored http session. see naming above at rec:stop[:name] 
+    const playback = new HttpTestPlayback({testDataDirectory: 'YOUR-TEST-DIRECTORY'});
 
     // parameters should match the settings used in `textRecorder.captureLuis()`
     const luisRecognizer = new LuisRecognizer({
@@ -75,8 +76,8 @@ describe('My bot', () => {
       }
     });
 
-    // see naming above at rec:stop[:name]
-    playback.load('my-stored-http-session');
+    // file name of your stored http session
+    playback.load('YOUR-TEST-FILE');
 
     // execute the test logic
     await adapter


### PR DESCRIPTION
otherwise it defaults to, for example: C:\microsoft\repos\bots\samples\testplayback\javascript\node_modules\mocha\bin\test\data\