### PR TITLE
fix typo

### DIFF
--- a/packages/botbuilder-http-test-recorder/README.md
+++ b/packages/botbuilder-http-test-recorder/README.md
@@ -25,7 +25,7 @@ Because this package is supplied as sample code, it is not available on npm and 
 
 > JavaScript examples are shown below, but this package also works great in TypeScript projects.
 
-### Recording HTTP traffic in the bot (Luis, Azure, and QnAMaker)
+### Recording HTTP traffic in the bot (Luis, AzureSearch, and QnAMaker)
 
 This sample shows how to capture traffic from Luis, AzureSearch, and QnAMaker.
 

--- a/packages/botbuilder-http-test-recorder/README.md
+++ b/packages/botbuilder-http-test-recorder/README.md
@@ -25,7 +25,7 @@ Because this package is supplied as sample code, it is not available on npm and 
 
 > JavaScript examples are shown below, but this package also works great in TypeScript projects.
 
-### Recording HTTP traffic in the bot (Luis, AzureSearch, and QnAMaker)
+### Recording HTTP traffic in the bot (Luis, Azure Search, and QnAMaker)
 
 This sample shows how to capture traffic from Luis, AzureSearch, and QnAMaker.
 


### PR DESCRIPTION
"Azure" to "AzureSearch"